### PR TITLE
fix(events): should have a general listener for emitting changes

### DIFF
--- a/index.js
+++ b/index.js
@@ -89,9 +89,8 @@ var Model = function (initialState, options) {
       controller.emit('flush', changes);
     }
 
+    tree.on('update', onUpdate);
     controller.on('change', function () {
-      tree.off('update', onUpdate);
-      tree.once('update', onUpdate);
       tree.commit();
     });
 


### PR DESCRIPTION
For some reason on mobile the `.off` -> `.once` approach does not work. The event does not trigger. But this is the wrong approach anyways, it should just have a general listener.
